### PR TITLE
Dev/refactor offsets

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -257,6 +257,14 @@ class Rule
 
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
+
+			if ( 'whitsun' === $rule['SPECIAL'] )
+			{
+				$year_days = array(-221,-220,-219,-218,-217,-216,-215);
+				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
+
+            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
+			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
 			{

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -275,7 +275,7 @@ class Rule
 				}
 	
 				// Offset after
-				// return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=2,3,4,5,6,7,8';
+				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-180,-179,-178,-177,-176,-175,-174';
 			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -86,17 +86,60 @@ class Rule
 	 * @var array
 	 */
 	private static $special_rules = array(
-		'newYear' => 'BYMONTH=1;BYMONTHDAY=1',
-		'palmSunday' => '',
-		'easter' => '',
-		'mayDay' => 'BYMONTH=5;BYDAY=1MO',
-		'whitsun' => 'BYMONTH=5;BYDAY=-1MO',
-		'independence' => 'BYMONTH=7;BYMONTHDAY=4',
-		'5SU47' => 'BYDAY=SU;BYYEARDAY=-156,-155,-154,-125,-124,-123,-94',
-		'summer' => 'BYMONTH=8;BYDAY=-1MO',
-		'thanksgiving' => 'BYMONTH=11;BYDAY=4TH',
-		'christmas' => 'BYMONTH=12;BYMONTHDAY=25',
-		'boxingDay' => 'BYMONTH=12;BYMONTHDAY=26',
+		'newYear' => array(
+			'rule' => 'BYMONTH=1;BYMONTHDAY=1',
+			'byyearday' => 1,
+			'category' => 'fixedDate'),
+
+		'palmSunday' => array(
+			'rule' => '',
+			'byyearday' => '',
+			'category' => 'easter'),
+
+		'easter' => array(
+			'rule' => '',
+			'byyearday' => '',
+			'category' => 'easter'),
+
+		'mayDay' => array(
+			'rule' => 'BYMONTH=5;BYDAY=1MO',
+			'byyearday' => array(-245,-244,-243,-242,-241,-240,-239),
+			'category' => 'fixedDay'),
+
+		'whitsun' => array(
+			'rule' => 'BYMONTH=5;BYDAY=-1MO',
+			'byyearday' => array(-221,-220,-219,-218,-217,-216,-215),
+			'category' => 'fixedDay'),
+
+		'independence' => array(
+			'rule' => 'BYMONTH=7;BYMONTHDAY=4',
+			'byyearday' => -181,
+			'category' => 'fixedDate'),
+
+		'5SU47' => array(
+			'rule' => 'BYDAY=SU;BYYEARDAY=-156,-155,-154,-125,-124,-123,-94',
+			'byyearday' => array(-156,-155,-154,-125,-124,-123,-94),
+			'category' => 'fixedDay'),
+
+		'summer' => array(
+			'rule' => 'BYMONTH=8;BYDAY=-1MO',
+			'byyearday' => array(-129,-128,-127,-126,-125,-124,-123),
+			'category' => 'fixedDay'),
+
+		'thanksgiving' => array(
+			'rule' => 'BYMONTH=11;BYDAY=4TH',
+			'byyearday' => array(-40,-39,-38,-37,-36,-35,-34),
+			'category' => 'fixedDay'),
+
+		'christmas' => array(
+			'rule' => 'BYMONTH=12;BYMONTHDAY=25',
+			'byyearday' => -7,
+			'category' => 'fixedDate'),
+
+		'boxingDay' => array(
+			'rule' => 'BYMONTH=12;BYMONTHDAY=26',
+			'byyearday' => -6,
+			'category' => 'fixedDate'),
 
 	);
 
@@ -336,7 +379,7 @@ class Rule
 			return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=2,3,4,5,6,7,8';
 		}
 
-		return 'FREQ=YEARLY;INTERVAL=1;' . $this::$special_rules[$rule['SPECIAL']];
+		return 'FREQ=YEARLY;INTERVAL=1;' . $this::$special_rules[$rule['SPECIAL']]['rule'];
 	}
 
 	/**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -252,11 +252,10 @@ class Rule
 
 			if ( 'mayDay' === $rule['SPECIAL'] )
 			{
-				$days = array(-245, -244, -243, -242, -241, -240, -239);
+				$year_days = array(-245, -244, -243, -242, -241, -240, -239);
 				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
-				var_dump($offset_n);
 
-            	return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=' . $day . ';BYYEARDAY=' . $this->offset_days( $days, $offset_n );
+            	return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
@@ -272,7 +271,14 @@ class Rule
 		return 'FREQ=YEARLY;INTERVAL=1;' . $this::$special_rules[$rule['SPECIAL']];
 	}
 
-	protected function offset_days( array $days, int $offset ) : string
+	/**
+	 * Offset a BYYEARDAY sequence.
+	 *
+	 * @param integer[] $days 	Array of BYYEARDAY values.
+	 * @param integer $offset	Offset amount <= +/-7.
+	 * @return string
+	 */
+	protected function offset_byyearday( array $days, int $offset ) : string
 	{
 		// Add offset to each day.
 		foreach ($days as &$value) 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -265,6 +265,18 @@ class Rule
 
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
+
+			if ( 'independence' === $rule['SPECIAL'] )
+			{
+				if ( substr($rule['OFFSET'], 0, 1) === '-' )
+				{
+					// Offset before
+					return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-188,-187,-186,-185,-184,-183,-182';
+				}
+	
+				// Offset after
+				// return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=2,3,4,5,6,7,8';
+			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
 			{

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -266,6 +266,14 @@ class Rule
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
 
+			if ( '5SU47' === $rule['SPECIAL'] )
+			{
+				$year_days = array(-156,-155,-154,-125,-124,-123,-94);
+				$offset_n = $this->calculate_offset_days( 'SU', $rule['OFFSET'] );
+
+            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
+			}
+
 			if ( 'independence' === $rule['SPECIAL'] )
 			{
 				if ( substr($rule['OFFSET'], 0, 1) === '-' )

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -181,15 +181,26 @@ class Rule
 			return 'FREQ=YEARLY;INTERVAL=1;BYMONTH='. $rule['BYMONTH'] . ';BYDAY=' . $rule['BYDAY'];
 		}
 
+		$month_week = (int) substr($rule['BYDAY'], 0, -2);
+
 		$day = substr($rule['OFFSET'], -2);
 		$offset = $this->calculate_offset_days( substr($rule['BYDAY'], -2), $rule['OFFSET'] );
 
 		$offset_sign = (int) substr($rule['OFFSET'], 0, -2);
-		$year_day = $this::$first_of_month[$rule['BYMONTH']];
+		$year_day = $this::$first_of_month[$rule['BYMONTH']] + 7 * ($month_week -1);
+
+		if ($month_week === -1) {
+			/**
+			 * The start of the last week of each month is 7 days before 
+			 * the first day of the next month.
+			 */
+			$year_day = $this::$first_of_month[$rule['BYMONTH'] + 1] -7;
+		}
+	
 		$week = $this->create_week($year_day);
 		$year_days = $this->offset_byyearday( $week, $offset );
 
-		return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $year_days;
+		return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $year_days ;
 	}
 	
 	/**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -255,17 +255,17 @@ class Rule
 				$year_days = array(-245, -244, -243, -242, -241, -240, -239);
 				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
 
-            	return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
+            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
 			{
 				// Offset before
-				return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=' . $day . ';BYYEARDAY=-1,-2,-3,-4,-5,-6,-7';
+				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-1,-2,-3,-4,-5,-6,-7';
 			}
 
 			// Offset after
-			return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=' . $day . ';BYYEARDAY=2,3,4,5,6,7,8';
+			return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=2,3,4,5,6,7,8';
 		}
 
 		return 'FREQ=YEARLY;INTERVAL=1;' . $this::$special_rules[$rule['SPECIAL']];

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -249,6 +249,11 @@ class Rule
 		if ( isset( $rule['OFFSET'] ) )
 		{
 			$day = substr($rule['OFFSET'], -2);
+
+			if ( 'mayDay' === $rule['SPECIAL'] )
+			{
+            	return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-252,-251,-250,-249,-248,-247,-246';
+			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
 			{

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -301,6 +301,18 @@ class Rule
 				// Offset after
 				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-180,-179,-178,-177,-176,-175,-174';
 			}
+
+			if ( 'christmas' === $rule['SPECIAL'] )
+			{
+				if ( substr($rule['OFFSET'], 0, 1) === '-' )
+				{
+					// Offset before
+					return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-14,-13,-12,-11,-10,-9,-8';
+				}
+	
+				// Offset after
+				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-6,-5,-4,-3,-2,-1,1';
+			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
 			{

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -282,6 +282,14 @@ class Rule
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
 
+			if ( 'thanksgiving' === $rule['SPECIAL'] )
+			{
+				$year_days = array(-40,-39,-38,-37,-36,-35,-34);
+				$offset_n = $this->calculate_offset_days( 'TH', $rule['OFFSET'] );
+
+            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
+			}
+
 			if ( 'independence' === $rule['SPECIAL'] )
 			{
 				if ( substr($rule['OFFSET'], 0, 1) === '-' )

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -313,6 +313,18 @@ class Rule
 				// Offset after
 				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-6,-5,-4,-3,-2,-1,1';
 			}
+
+			if ( 'boxingDay' === $rule['SPECIAL'] )
+			{
+				if ( substr($rule['OFFSET'], 0, 1) === '-' )
+				{
+					// Offset before
+					return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-13,-12,-11,-10,-9,-8,-7';
+				}
+	
+				// Offset after
+				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-5,-4,-3,-2,-1,1,2';
+			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
 			{

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -104,11 +104,13 @@ class Rule
 		'mayDay' => array(
 			'rule' => 'BYMONTH=5;BYDAY=1MO',
 			'byyearday' => array(-245,-244,-243,-242,-241,-240,-239),
+			'byday' => 'MO',
 			'category' => 'fixedDay'),
 
 		'whitsun' => array(
 			'rule' => 'BYMONTH=5;BYDAY=-1MO',
 			'byyearday' => array(-221,-220,-219,-218,-217,-216,-215),
+			'byday' => 'MO',
 			'category' => 'fixedDay'),
 
 		'independence' => array(
@@ -119,16 +121,19 @@ class Rule
 		'5SU47' => array(
 			'rule' => 'BYDAY=SU;BYYEARDAY=-156,-155,-154,-125,-124,-123,-94',
 			'byyearday' => array(-156,-155,-154,-125,-124,-123,-94),
+			'byday' => 'SU',
 			'category' => 'fixedDay'),
 
 		'summer' => array(
 			'rule' => 'BYMONTH=8;BYDAY=-1MO',
 			'byyearday' => array(-129,-128,-127,-126,-125,-124,-123),
+			'byday' => 'MO',
 			'category' => 'fixedDay'),
 
 		'thanksgiving' => array(
 			'rule' => 'BYMONTH=11;BYDAY=4TH',
 			'byyearday' => array(-40,-39,-38,-37,-36,-35,-34),
+			'byday' => 'TH',
 			'category' => 'fixedDay'),
 
 		'christmas' => array(
@@ -293,42 +298,11 @@ class Rule
 		{
 			$day = substr($rule['OFFSET'], -2);
 
-			if ( 'mayDay' === $rule['SPECIAL'] )
+			if ( 'fixedDay' === $this::$special_rules[$rule['SPECIAL']]['category'] )
 			{
-				$year_days = array(-245, -244, -243, -242, -241, -240, -239);
-				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
-
-            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
-			}
-
-			if ( 'whitsun' === $rule['SPECIAL'] )
-			{
-				$year_days = array(-221,-220,-219,-218,-217,-216,-215);
-				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
-
-            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
-			}
-
-			if ( '5SU47' === $rule['SPECIAL'] )
-			{
-				$year_days = array(-156,-155,-154,-125,-124,-123,-94);
-				$offset_n = $this->calculate_offset_days( 'SU', $rule['OFFSET'] );
-
-            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
-			}
-
-			if ( 'summer' === $rule['SPECIAL'] )
-			{
-				$year_days = array(-129,-128,-127,-126,-125,-124,-123);
-				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
-
-            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
-			}
-
-			if ( 'thanksgiving' === $rule['SPECIAL'] )
-			{
-				$year_days = array(-40,-39,-38,-37,-36,-35,-34);
-				$offset_n = $this->calculate_offset_days( 'TH', $rule['OFFSET'] );
+				$year_days = $this::$special_rules[$rule['SPECIAL']]['byyearday'];
+				$special_day = $this::$special_rules[$rule['SPECIAL']]['byday'];
+				$offset_n = $this->calculate_offset_days( $special_day, $rule['OFFSET'] );
 
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -351,20 +351,20 @@ class Rule
 	
 		$output = array();
 		$limit = 7;
+
 		for ($i = 1; $i<=$limit; $i++) 
 		{
 			$value = $year_day + $i * $offset;
 			
+			// Skip 0 if crossing year end. 
 			if ($value !== 0) {
 				$output[] = $year_day + $i * $offset;
 			} else {
-				// Skip 0 if crossing year end. 
 				$limit++;
 			}
 		}
 	
-		// This is just because I wrote my tests backwards.
-		// TODO: fix tests.
+		// Standardise order to largest absolute value first.
 		if ( $offset < 0 ) 
 		{
 			$output = array_reverse($output);

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -307,50 +307,13 @@ class Rule
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
 
-			if ( 'independence' === $rule['SPECIAL'] )
-			{
-				if ( substr($rule['OFFSET'], 0, 1) === '-' )
-				{
-					// Offset before
-					return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-188,-187,-186,-185,-184,-183,-182';
-				}
-	
-				// Offset after
-				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-180,-179,-178,-177,-176,-175,-174';
-			}
+			// Category = fixedDate
+			$offset_sign = (int) substr($rule['OFFSET'], 0, -2);
+			$year_day = $this::$special_rules[$rule['SPECIAL']]['byyearday'];
+			$year_days = $this->offset_byyearday_fixed_date( $year_day, $offset_sign );
 
-			if ( 'christmas' === $rule['SPECIAL'] )
-			{
-				if ( substr($rule['OFFSET'], 0, 1) === '-' )
-				{
-					// Offset before
-					return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-14,-13,-12,-11,-10,-9,-8';
-				}
-	
-				// Offset after
-				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-6,-5,-4,-3,-2,-1,1';
-			}
-
-			if ( 'boxingDay' === $rule['SPECIAL'] )
-			{
-				if ( substr($rule['OFFSET'], 0, 1) === '-' )
-				{
-					// Offset before
-					return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-13,-12,-11,-10,-9,-8,-7';
-				}
-	
-				// Offset after
-				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-5,-4,-3,-2,-1,1,2';
-			}
+			return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $year_days;
 			
-			if ( substr($rule['OFFSET'], 0, 1) === '-' )
-			{
-				// Offset before
-				return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=-1,-2,-3,-4,-5,-6,-7';
-			}
-
-			// Offset after
-			return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=2,3,4,5,6,7,8';
 		}
 
 		return 'FREQ=YEARLY;INTERVAL=1;' . $this::$special_rules[$rule['SPECIAL']]['rule'];
@@ -371,6 +334,42 @@ class Rule
 			$value += $offset;
 		}
 		return implode(',', $days);
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * @param integer $year_day
+	 * @param integer $offset
+	 * @return string
+	 */
+	protected function offset_byyearday_fixed_date( int $year_day, int $offset ) : string
+	{
+		if (abs($offset) !== 1) {
+			throw new \InvalidArgumentException('Offset should be 1 or -1. Got [' . $offset . ']');
+		}
+	
+		$output = array();
+		$limit = 7;
+		for ($i = 1; $i<=$limit; $i++) 
+		{
+			$value = $year_day + $i * $offset;
+			
+			if ($value !== 0) {
+				$output[] = $year_day + $i * $offset;
+			} else {
+				// Skip 0 if crossing year end. 
+				$limit++;
+			}
+		}
+	
+		// This is just because I wrote my tests backwards.
+		// TODO: fix tests.
+		if ( $offset < 0 ) 
+		{
+			$output = array_reverse($output);
+		}
+		return implode(',', $output);
 	}
 
 	/**

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -252,7 +252,11 @@ class Rule
 
 			if ( 'mayDay' === $rule['SPECIAL'] )
 			{
-            	return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-252,-251,-250,-249,-248,-247,-246';
+				$days = array(-245, -244, -243, -242, -241, -240, -239);
+				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
+				var_dump($offset_n);
+
+            	return 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=' . $day . ';BYYEARDAY=' . $this->offset_days( $days, $offset_n );
 			}
 			
 			if ( substr($rule['OFFSET'], 0, 1) === '-' )
@@ -266,6 +270,16 @@ class Rule
 		}
 
 		return 'FREQ=YEARLY;INTERVAL=1;' . $this::$special_rules[$rule['SPECIAL']];
+	}
+
+	protected function offset_days( array $days, int $offset ) : string
+	{
+		// Add offset to each day.
+		foreach ($days as &$value) 
+		{
+			$value += $offset;
+		}
+		return implode(',', $days);
 	}
 
 	/**
@@ -372,7 +386,13 @@ class Rule
 	{
 		$day = \RRule\RRule::$week_days[$day];
 		$offset_sign = (int) substr($offset, 0, -2);
-		$offset = $offset_sign * \RRule\RRule::$week_days[substr($offset, -2)];
+		$offset_value = \RRule\RRule::$week_days[substr($offset, -2)];
+		$offset = $offset_sign * $offset_value;
+
+		if ($day === $offset_value)
+		{
+			return $offset_sign * 7;
+		}
 
 		// I can only explain this maths by diagram!
 		if ( ($offset - $offset_sign * $day) < 0 ) 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -274,6 +274,14 @@ class Rule
             	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
 			}
 
+			if ( 'summer' === $rule['SPECIAL'] )
+			{
+				$year_days = array(-129,-128,-127,-126,-125,-124,-123);
+				$offset_n = $this->calculate_offset_days( 'MO', $rule['OFFSET'] );
+
+            	return 'FREQ=YEARLY;INTERVAL=1;BYDAY=' . $day . ';BYYEARDAY=' . $this->offset_byyearday( $year_days, $offset_n );
+			}
+
 			if ( 'independence' === $rule['SPECIAL'] )
 			{
 				if ( substr($rule['OFFSET'], 0, 1) === '-' )

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -299,7 +299,7 @@ class Rule
 	 * @param integer $offset	Offset amount <= +/-7.
 	 * @return string
 	 */
-	public function offset_byyearday( array $days, int $offset ) : string
+	protected function offset_byyearday( array $days, int $offset ) : string
 	{
 		// Add offset to each day.
 		foreach ($days as &$value) 

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -149,26 +149,6 @@ class Rule
 
 	);
 
-	/**
-	 * Addition function for days that span months or years.
-	 * 
-	 * Allows progression along a number line without zero:
-	 * e.g 3,2,1,-1,-2,-3
-	 * 
-	 * TODO: rename
-	 *
-	 * @param integer $year_day
-	 * @param integer $k
-	 * @return integer
-	 */
-	private function year_day(int $year_day, int $k): int
-	{
-		$sum = $year_day + $k;
-		if ($sum <= 0 ) {
-			return $sum - 1;
-		}
-		return $sum;
-	}
 
 	/**
 	 * 

--- a/stylesheets/override.css
+++ b/stylesheets/override.css
@@ -13,3 +13,7 @@ background-color:#ffffff;
 .govuk-heading-xl {
   line-height: normal;
 }
+
+pre {
+  white-space: pre-wrap;
+}

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -761,6 +761,14 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1MO',
                 ]
             ],
+            // After
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-180,-179,-178,-177,-176,-175,-174',
+                [
+                    'SPECIAL' => 'independence',
+                    'OFFSET' => '1MO',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -804,6 +804,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1TH',
                 ]
             ],
+            // Christmas
+            // -7
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-14,-13,-12,-11,-10,-9,-8',
+                [
+                    'SPECIAL' => 'christmas',
+                    'OFFSET' => '-1MO',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -786,6 +786,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '1SU',
                 ]
             ],
+            // Summer bank hol
+            // -129,-128,-127,-126,-125,-124,-123
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-136,-135,-134,-133,-132,-131,-130',
+                [
+                    'SPECIAL' => 'summer',
+                    'OFFSET' => '-1MO',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -951,8 +951,8 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
     /**
     * @dataProvider offsetBYYEARDAYDataProvider
     */
-    public function testOffsetBYYEARDAY(string $expectedValue, array $days, int $offset): void
-    {
-        $this->assertEquals($expectedValue, $this->rule->offset_byyearday($days, $offset));
-    }
+    // public function testOffsetBYYEARDAY(string $expectedValue, array $days, int $offset): void
+    // {
+    //     $this->assertEquals($expectedValue, $this->rule->offset_byyearday($days, $offset));
+    // }
 }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -714,6 +714,13 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1MO',
                 ]
             ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=TU;BYYEARDAY=-251,-250,-249,-248,-247,-246,-245',
+                [
+                    'SPECIAL' => 'mayDay',
+                    'OFFSET' => '-1TU',
+                ]
+            ],
 
         ];
     }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -839,16 +839,6 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
     }
 
 
-    /**
-     * Uses same invalid data for all fns
-     * @dataProvider invalidData
-     */
-    public function testThrowsException5545(array $inputValue): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->rule->rfc5545($inputValue);
-    }
-
     public function calculateOffsetDataProvider(): array
     {
         return [

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -535,14 +535,57 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                 ]
             ],
 
-            // // 1SA, 1FR etc
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYMONTH=1;BYDAY=1MO',
-            //     [
-            //         'BYMONTH' => 1,
-            //         'BYDAY' => '1MO',
-            //     ]
-            // ],
+            // 2SU
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYMONTH=1;BYDAY=2SU',
+                [
+                    'BYMONTH' => 1,
+                    'BYDAY' => '2SU',
+                ]
+            ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=7,8,9,10,11,12,13',
+                [
+                    'BYMONTH' => 1,
+                    'BYDAY' => '2SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-300,-299,-298,-297,-296,-295,-294',
+                [
+                    'BYMONTH' => 3,
+                    'BYDAY' => '2SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            // 3SU
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-293,-292,-291,-290,-289,-288,-287',
+                [
+                    'BYMONTH' => 3,
+                    'BYDAY' => '3SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            // 4SU
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-286,-285,-284,-283,-282,-281,-280',
+                [
+                    'BYMONTH' => 3,
+                    'BYDAY' => '4SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            // -1SU
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-283,-282,-281,-280,-279,-278,-277',
+                [
+                    'BYMONTH' => 3,
+                    'BYDAY' => '-1SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
 
 
             // Specials

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -685,14 +685,14 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
         return [
             // Before
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-1,-2,-3,-4,-5,-6,-7',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-1,-2,-3,-4,-5,-6,-7',
                 [
                     'SPECIAL' => 'newYear',
                     'OFFSET' => '-1MO',
                 ]
             ],
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=TU;BYYEARDAY=-1,-2,-3,-4,-5,-6,-7',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=-1,-2,-3,-4,-5,-6,-7',
                 [
                     'SPECIAL' => 'newYear',
                     'OFFSET' => '-1TU',
@@ -700,7 +700,7 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
             ],
             // After
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=2,3,4,5,6,7,8',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=2,3,4,5,6,7,8',
                 [
                     'SPECIAL' => 'newYear',
                     'OFFSET' => '1MO',
@@ -708,21 +708,21 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
             ],
             // May Day
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-252,-251,-250,-249,-248,-247,-246',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-252,-251,-250,-249,-248,-247,-246',
                 [
                     'SPECIAL' => 'mayDay',
                     'OFFSET' => '-1MO',
                 ]
             ],
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=TU;BYYEARDAY=-251,-250,-249,-248,-247,-246,-245',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=-251,-250,-249,-248,-247,-246,-245',
                 [
                     'SPECIAL' => 'mayDay',
                     'OFFSET' => '-1TU',
                 ]
             ],
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=SU;BYYEARDAY=-246,-245,-244,-243,-242,-241,-240',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SU;BYYEARDAY=-246,-245,-244,-243,-242,-241,-240',
                 [
                     'SPECIAL' => 'mayDay',
                     'OFFSET' => '-1SU',
@@ -730,14 +730,14 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
             ],
             // After
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=TU;BYYEARDAY=-244,-243,-242,-241,-240,-239,-238',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=-244,-243,-242,-241,-240,-239,-238',
                 [
                     'SPECIAL' => 'mayDay',
                     'OFFSET' => '1TU',
                 ]
             ],
             [
-                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-238,-237,-236,-235,-234,-233,-232',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-238,-237,-236,-235,-234,-233,-232',
                 [
                     'SPECIAL' => 'mayDay',
                     'OFFSET' => '1MO',

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -423,194 +423,196 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1SA'
                 ]
             ],
+            // First week of March:
+            // -306,-305,-304,-303,-302,-301,-300
             [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=59,60,61,62,63,64,65,66',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-307,-306,-305,-304,-303,-302,-301',
                 [
                     'BYMONTH' => 3,
                     'BYDAY' => '1SU',
                     'OFFSET' => '-1SA'
                 ]
             ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=90,91,92,93,94,95,96,97',
-                [
-                    'BYMONTH' => 4,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=120,121,122,123,124,125,126,127',
-                [
-                    'BYMONTH' => 5,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=151,152,153,154,155,156,157,158',
-                [
-                    'BYMONTH' => 6,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=181,182,183,184,185,186,187,188',
-                [
-                    'BYMONTH' => 7,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=212,213,214,215,216,217,218,219',
-                [
-                    'BYMONTH' => 8,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=243,244,245,246,247,248,249,250',
-                [
-                    'BYMONTH' => 9,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=273,274,275,276,277,278,279,280',
-                [
-                    'BYMONTH' => 10,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=304,305,306,307,308,309,310,311',
-                [
-                    'BYMONTH' => 11,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=334,335,336,337,338,339,340,341',
-                [
-                    'BYMONTH' => 12,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1SA'
-                ]
-            ],
-            // Friday before first Sun
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=-2,-1,1,2,3,4,5',
-                [
-                    'BYMONTH' => 1,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1FR'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=30,31,32,33,34,35,36',
-                [
-                    'BYMONTH' => 2,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1FR'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYMONTHDAY=-2,-1,1,2,3,4,5;BYYEARDAY=58,59,60,61,62,63,64,65',
-                [
-                    'BYMONTH' => 3,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1FR'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYMONTHDAY=-2,-1,1,2,3,4,5;BYYEARDAY=333,334,335,336,337,338,339,340',
-                [
-                    'BYMONTH' => 12,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1FR'
-                ]
-            ],
-            // Monday before first Sun
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-6,-5,-4,-3,-2,-1,1',
-                [
-                    'BYMONTH' => 1,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1MO'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=26,27,28,29,30,31,32',
-                [
-                    'BYMONTH' => 2,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1MO'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=-6,-5,-4,-3,-2,-1,1;BYYEARDAY=54,55,56,57,58,59,60,61',
-                [
-                    'BYMONTH' => 3,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1MO'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=-6,-5,-4,-3,-2,-1,1;BYYEARDAY=329,330,331,332,333,334,335,336',
-                [
-                    'BYMONTH' => 12,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '-1MO'
-                ]
-            ],
-            // Positive offsets
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=2,3,4,5,6,7,8',
-                [
-                    'BYMONTH' => 1,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '1MO'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=2,3,4,5,6,7,8;BYYEARDAY=61,62,63,64,65,66,67,68',
-                [
-                    'BYMONTH' => 3,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '1MO'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=3,4,5,6,7,8,9',
-                [
-                    'BYMONTH' => 1,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '1TU'
-                ]
-            ],
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=7,8,9,10,11,12,13',
-                [
-                    'BYMONTH' => 1,
-                    'BYDAY' => '1SU',
-                    'OFFSET' => '1SA'
-                ]
-            ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=90,91,92,93,94,95,96,97',
+            //     [
+            //         'BYMONTH' => 4,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=120,121,122,123,124,125,126,127',
+            //     [
+            //         'BYMONTH' => 5,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=151,152,153,154,155,156,157,158',
+            //     [
+            //         'BYMONTH' => 6,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=181,182,183,184,185,186,187,188',
+            //     [
+            //         'BYMONTH' => 7,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=212,213,214,215,216,217,218,219',
+            //     [
+            //         'BYMONTH' => 8,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=243,244,245,246,247,248,249,250',
+            //     [
+            //         'BYMONTH' => 9,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=273,274,275,276,277,278,279,280',
+            //     [
+            //         'BYMONTH' => 10,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=304,305,306,307,308,309,310,311',
+            //     [
+            //         'BYMONTH' => 11,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=334,335,336,337,338,339,340,341',
+            //     [
+            //         'BYMONTH' => 12,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1SA'
+            //     ]
+            // ],
+            // // Friday before first Sun
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=-2,-1,1,2,3,4,5',
+            //     [
+            //         'BYMONTH' => 1,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1FR'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=30,31,32,33,34,35,36',
+            //     [
+            //         'BYMONTH' => 2,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1FR'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYMONTHDAY=-2,-1,1,2,3,4,5;BYYEARDAY=58,59,60,61,62,63,64,65',
+            //     [
+            //         'BYMONTH' => 3,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1FR'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYMONTHDAY=-2,-1,1,2,3,4,5;BYYEARDAY=333,334,335,336,337,338,339,340',
+            //     [
+            //         'BYMONTH' => 12,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1FR'
+            //     ]
+            // ],
+            // // Monday before first Sun
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-6,-5,-4,-3,-2,-1,1',
+            //     [
+            //         'BYMONTH' => 1,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1MO'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=26,27,28,29,30,31,32',
+            //     [
+            //         'BYMONTH' => 2,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1MO'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=-6,-5,-4,-3,-2,-1,1;BYYEARDAY=54,55,56,57,58,59,60,61',
+            //     [
+            //         'BYMONTH' => 3,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1MO'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=-6,-5,-4,-3,-2,-1,1;BYYEARDAY=329,330,331,332,333,334,335,336',
+            //     [
+            //         'BYMONTH' => 12,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '-1MO'
+            //     ]
+            // ],
+            // // Positive offsets
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=2,3,4,5,6,7,8',
+            //     [
+            //         'BYMONTH' => 1,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '1MO'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=2,3,4,5,6,7,8;BYYEARDAY=61,62,63,64,65,66,67,68',
+            //     [
+            //         'BYMONTH' => 3,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '1MO'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=3,4,5,6,7,8,9',
+            //     [
+            //         'BYMONTH' => 1,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '1TU'
+            //     ]
+            // ],
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=7,8,9,10,11,12,13',
+            //     [
+            //         'BYMONTH' => 1,
+            //         'BYDAY' => '1SU',
+            //         'OFFSET' => '1SA'
+            //     ]
+            // ],
 
-            // 1SA, 1FR etc
-            [
-                'FREQ=YEARLY;INTERVAL=1;BYMONTH=1;BYDAY=1MO',
-                [
-                    'BYMONTH' => 1,
-                    'BYDAY' => '1MO',
-                ]
-            ],
+            // // 1SA, 1FR etc
+            // [
+            //     'FREQ=YEARLY;INTERVAL=1;BYMONTH=1;BYDAY=1MO',
+            //     [
+            //         'BYMONTH' => 1,
+            //         'BYDAY' => '1MO',
+            //     ]
+            // ],
 
 
             // Specials
@@ -901,5 +903,56 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
     public function testCalculateOffset(string $expectedValue, string $day, string $offset): void
     {
         $this->assertEquals($expectedValue, $this->rule->calculate_offset_days($day, $offset));
+    }
+
+    public function offsetBYYEARDAYDataProvider(): array
+    {
+        return [
+            [
+                '1,2,3,4,5,6,7',
+                [2,3,4,5,6,7,8],
+                -1
+            ],
+            [
+                '-10,-9,-8,-7,-6,-5,-4',
+                [-9,-8,-7,-6,-5,-4,-3],
+                -1
+            ],
+            [
+                '-1,1,2,3,4,5,6',
+                [1,2,3,4,5,6,7],
+                -1
+            ],
+            [
+                '-1,1,2,3,4,5,6',
+                [7,8,9,10,11,12,13],
+                -7
+            ],
+            [
+                '3,4,5,6,7,8,9',
+                [2,3,4,5,6,7,8],
+                1
+            ],
+            [
+                '-6,-5,-4,-3,-2,-1,1',
+                [-7,-6,-5,-4,-3,-2,-1],
+                1
+            ],
+            [
+                '-3,-2,-1,1,2,3,4',
+                [-7,-6,-5,-4,-3,-2,-1],
+                4
+            ],
+            
+
+        ];
+    }
+
+    /**
+    * @dataProvider offsetBYYEARDAYDataProvider
+    */
+    public function testOffsetBYYEARDAY(string $expectedValue, array $days, int $offset): void
+    {
+        $this->assertEquals($expectedValue, $this->rule->offset_byyearday($days, $offset));
     }
 }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -816,7 +816,7 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
             // Boxing Day
             // -6
             [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-5,-4,-3,-2,-1,1,2',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SU;BYYEARDAY=-5,-4,-3,-2,-1,1,2',
                 [
                     'SPECIAL' => 'boxingDay',
                     'OFFSET' => '1SU',

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -433,177 +433,107 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1SA'
                 ]
             ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=90,91,92,93,94,95,96,97',
-            //     [
-            //         'BYMONTH' => 4,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=120,121,122,123,124,125,126,127',
-            //     [
-            //         'BYMONTH' => 5,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=151,152,153,154,155,156,157,158',
-            //     [
-            //         'BYMONTH' => 6,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=181,182,183,184,185,186,187,188',
-            //     [
-            //         'BYMONTH' => 7,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=212,213,214,215,216,217,218,219',
-            //     [
-            //         'BYMONTH' => 8,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=243,244,245,246,247,248,249,250',
-            //     [
-            //         'BYMONTH' => 9,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=273,274,275,276,277,278,279,280',
-            //     [
-            //         'BYMONTH' => 10,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=304,305,306,307,308,309,310,311',
-            //     [
-            //         'BYMONTH' => 11,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=-1,1,2,3,4,5,6;BYYEARDAY=334,335,336,337,338,339,340,341',
-            //     [
-            //         'BYMONTH' => 12,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1SA'
-            //     ]
-            // ],
-            // // Friday before first Sun
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=-2,-1,1,2,3,4,5',
-            //     [
-            //         'BYMONTH' => 1,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1FR'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=30,31,32,33,34,35,36',
-            //     [
-            //         'BYMONTH' => 2,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1FR'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYMONTHDAY=-2,-1,1,2,3,4,5;BYYEARDAY=58,59,60,61,62,63,64,65',
-            //     [
-            //         'BYMONTH' => 3,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1FR'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYMONTHDAY=-2,-1,1,2,3,4,5;BYYEARDAY=333,334,335,336,337,338,339,340',
-            //     [
-            //         'BYMONTH' => 12,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1FR'
-            //     ]
-            // ],
-            // // Monday before first Sun
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-6,-5,-4,-3,-2,-1,1',
-            //     [
-            //         'BYMONTH' => 1,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1MO'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=26,27,28,29,30,31,32',
-            //     [
-            //         'BYMONTH' => 2,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1MO'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=-6,-5,-4,-3,-2,-1,1;BYYEARDAY=54,55,56,57,58,59,60,61',
-            //     [
-            //         'BYMONTH' => 3,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1MO'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=-6,-5,-4,-3,-2,-1,1;BYYEARDAY=329,330,331,332,333,334,335,336',
-            //     [
-            //         'BYMONTH' => 12,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '-1MO'
-            //     ]
-            // ],
-            // // Positive offsets
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=2,3,4,5,6,7,8',
-            //     [
-            //         'BYMONTH' => 1,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '1MO'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYMONTHDAY=2,3,4,5,6,7,8;BYYEARDAY=61,62,63,64,65,66,67,68',
-            //     [
-            //         'BYMONTH' => 3,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '1MO'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=3,4,5,6,7,8,9',
-            //     [
-            //         'BYMONTH' => 1,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '1TU'
-            //     ]
-            // ],
-            // [
-            //     'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=7,8,9,10,11,12,13',
-            //     [
-            //         'BYMONTH' => 1,
-            //         'BYDAY' => '1SU',
-            //         'OFFSET' => '1SA'
-            //     ]
-            // ],
+            // First week of April:
+            // -275,-274,-273,-272,-271,-270,-269
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-276,-275,-274,-273,-272,-271,-270',
+                [
+                    'BYMONTH' => 4,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            // First week of May:
+            // -245,-244,-243,-242,-241,-240,-239
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-246,-245,-244,-243,-242,-241,-240',
+                [
+                    'BYMONTH' => 5,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            // First week of June:
+            // -214,-213,-212,-211,-210,-209,-208
+            [
+            'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-215,-214,-213,-212,-211,-210,-209',
+                [
+                    'BYMONTH' => 6,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1SA'
+                ]
+            ],
+            // Friday before first Sun
+            // BYYEARDAY span
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=-2,-1,1,2,3,4,5',
+                [
+                    'BYMONTH' => 1,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1FR'
+                ]
+            ],
+            // Positive BYYEARDAY
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=30,31,32,33,34,35,36',
+                [
+                    'BYMONTH' => 2,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1FR'
+                ]
+            ],
+            // Negative BYYEARDAY
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=FR;BYYEARDAY=-308,-307,-306,-305,-304,-303,-302',
+                [
+                    'BYMONTH' => 3,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1FR'
+                ]
+            ],
+            // Monday before first Sun
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-6,-5,-4,-3,-2,-1,1',
+                [
+                    'BYMONTH' => 1,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1MO'
+                ]
+            ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=26,27,28,29,30,31,32',
+                [
+                    'BYMONTH' => 2,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1MO'
+                ]
+            ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-312,-311,-310,-309,-308,-307,-306',
+                [
+                    'BYMONTH' => 3,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '-1MO'
+                ]
+            ],
+            // Positive offsets
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=2,3,4,5,6,7,8',
+                [
+                    'BYMONTH' => 1,
+                    'BYDAY' => '1SU',
+                    'OFFSET' => '1MO'
+                ]
+            ],
+
+            // 1SA, 1FR etc
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYMONTH=1;BYDAY=1MO',
+                [
+                    'BYMONTH' => 1,
+                    'BYDAY' => '1MO',
+                ]
+            ],
 
             // // 1SA, 1FR etc
             // [

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -728,6 +728,13 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1SU',
                 ]
             ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=TU;BYYEARDAY=-244,-243,-242,-241,-240,-239,-238',
+                [
+                    'SPECIAL' => 'mayDay',
+                    'OFFSET' => '1TU',
+                ]
+            ],
 
         ];
     }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -752,6 +752,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1MO',
                 ]
             ],
+            // Independence
+            // -181
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-188,-187,-186,-185,-184,-183,-182',
+                [
+                    'SPECIAL' => 'independence',
+                    'OFFSET' => '-1MO',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -769,6 +769,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '1MO',
                 ]
             ],
+            // First fifth Sunday after the 4th July
+            // -156,-155,-154,-125,-124,-123,-94
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SA;BYYEARDAY=-157,-156,-155,-126,-125,-124,-95',
+                [
+                    'SPECIAL' => '5SU47',
+                    'OFFSET' => '-1SA',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -706,6 +706,14 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '1MO',
                 ]
             ],
+            // May Day
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-252,-251,-250,-249,-248,-247,-246',
+                [
+                    'SPECIAL' => 'mayDay',
+                    'OFFSET' => '-1MO',
+                ]
+            ],
 
         ];
     }

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -743,7 +743,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '1MO',
                 ]
             ],
-
+            // Whitsun
+            // -221,-220,-219,-218,-217,-216,-215
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-228,-227,-226,-225,-224,-223,-222',
+                [
+                    'SPECIAL' => 'whitsun',
+                    'OFFSET' => '-1MO',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -778,6 +778,14 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1SA',
                 ]
             ],
+            // After
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=SU;BYYEARDAY=-149,-148,-147,-118,-117,-116,-87',
+                [
+                    'SPECIAL' => '5SU47',
+                    'OFFSET' => '1SU',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -685,14 +685,14 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
         return [
             // Before
             [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-1,-2,-3,-4,-5,-6,-7',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-7,-6,-5,-4,-3,-2,-1',
                 [
                     'SPECIAL' => 'newYear',
                     'OFFSET' => '-1MO',
                 ]
             ],
             [
-                'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=-1,-2,-3,-4,-5,-6,-7',
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=TU;BYYEARDAY=-7,-6,-5,-4,-3,-2,-1',
                 [
                     'SPECIAL' => 'newYear',
                     'OFFSET' => '-1TU',

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -795,6 +795,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1MO',
                 ]
             ],
+            // Thanksgiving
+            // -40,-39,-38,-37,-36,-35,-34
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=TH;BYYEARDAY=-47,-46,-45,-44,-43,-42,-41',
+                [
+                    'SPECIAL' => 'thanksgiving',
+                    'OFFSET' => '-1TH',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -728,11 +728,19 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1SU',
                 ]
             ],
+            // After
             [
                 'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=TU;BYYEARDAY=-244,-243,-242,-241,-240,-239,-238',
                 [
                     'SPECIAL' => 'mayDay',
                     'OFFSET' => '1TU',
+                ]
+            ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=MO;BYYEARDAY=-238,-237,-236,-235,-234,-233,-232',
+                [
+                    'SPECIAL' => 'mayDay',
+                    'OFFSET' => '1MO',
                 ]
             ],
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -327,6 +327,11 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
             [[
                 'SPECIAL' => 'garbage',
             ]],
+            // Offset more than a week
+            [[
+                'SPECIAL' => 'mayDay',
+                'OFFSET' => '2TU',
+            ]]
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -813,6 +813,15 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1MO',
                 ]
             ],
+            // Boxing Day
+            // -6
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYDAY=MO;BYYEARDAY=-5,-4,-3,-2,-1,1,2',
+                [
+                    'SPECIAL' => 'boxingDay',
+                    'OFFSET' => '1SU',
+                ]
+            ],
         ];
     }
 

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -721,6 +721,13 @@ class RuleTest extends TestCase  # Has to be [ClassName]Test
                     'OFFSET' => '-1TU',
                 ]
             ],
+            [
+                'FREQ=YEARLY;INTERVAL=1;BYWEEKDAY=SU;BYYEARDAY=-246,-245,-244,-243,-242,-241,-240',
+                [
+                    'SPECIAL' => 'mayDay',
+                    'OFFSET' => '-1SU',
+                ]
+            ],
 
         ];
     }


### PR DESCRIPTION
Change format of RFC5545 output when days are offset to consistent BYYEARDAY formula. For Jan-Feb, BYYEARDAY is positive; for March–Dec, BYYEARDAY is negative, counting from the end of the year, which allows for leap years.